### PR TITLE
fix: システムのダークモード設定がアプリに適用されないようにする

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './app/components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## 概要
macOSのダークモード設定がアプリのUIに意図せず適用される問題を修正しました。

## 変更内容
- `tailwind.config.js`に`darkMode: 'class'`を追加
- これによりシステム設定（`prefers-color-scheme`）ではなく、明示的に`<html class="dark">`を付与した場合のみダークモードが適用されるようになります

## 背景
Tailwindのデフォルト設定（`darkMode: 'media'`）ではOSのダークモード設定に自動追従するため、テーブルや一部UIコンポーネントでスタイルが崩れる問題がありました。