### PR TITLE
chore(deps): bump @supabase/supabase-js from 2.39.1 to 2.97.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@supabase/ssr": "^0.8.0",
-        "@supabase/supabase-js": "^2.39.1",
+        "@supabase/supabase-js": "^2.97.0",
         "@types/node": "20.8.10",
         "@types/react": "18.2.34",
         "@types/react-dom": "18.2.14",
@@ -6492,7 +6492,6 @@
       "version": "2.97.0",
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.97.0.tgz",
       "integrity": "sha512-kTD91rZNO4LvRUHv4x3/4hNmsEd2ofkYhuba2VMUPRVef1RCmnHtm7rIws38Fg0yQnOSZOplQzafn0GSiy6GVg==",
-      "license": "MIT",
       "dependencies": {
         "@supabase/auth-js": "2.97.0",
         "@supabase/functions-js": "2.97.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
     "@supabase/ssr": "^0.8.0",
-    "@supabase/supabase-js": "^2.39.1",
+    "@supabase/supabase-js": "^2.97.0",
     "@types/node": "20.8.10",
     "@types/react": "18.2.34",
     "@types/react-dom": "18.2.14",


### PR DESCRIPTION
Bumps @supabase/supabase-js from 2.39.1 to 2.97.0. PostgrestError mock fixes were already applied in #349.