### PR TITLE
fix: Playwright HTMLレポーターのブロック防止とflakyテストのリトライ設定

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,12 +23,12 @@ export default defineConfig({
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  /* Retry failed tests to handle flaky failures */
+  retries: process.env.CI ? 2 : 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [['html', { open: 'never' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
## 変更内容

### 問題
- `npm run test:e2e` 実行後、HTMLレポートサーバーが起動してプロセスがブロックされ、コマンドが終了しなかった
- Firefox の `NS_BINDING_ABORTED` による flaky テストが発生していた

### 修正
- **reporter**: `'html'` → `[['html', { open: 'never' }]]` に変更し、テスト完了後に自動でレポートサーバーを開かないようにした（レポートは `npx playwright show-report` で手動確認可能）
- **retries**: ローカル環境で `0` → `1` に変更し、flaky テストのリトライに対応

### テスト結果
- Playwright: 18 passed (18.9s)、コマンド正常終了を確認済み