### PR TITLE
fix: 型安全性・エラーハンドリング改善 (supabaseListener, usePostHelp, dashboard)

### DIFF
--- a/app/(feature)/dashboard/error.tsx
+++ b/app/(feature)/dashboard/error.tsx
@@ -1,0 +1,19 @@
+'use client';
+import React from 'react';
+
+const Error: React.FC<{ error: Error; reset: () => void }> = ({
+  error,
+  reset,
+}) => {
+  return (
+    <div>
+      <p>pageのError</p>
+      <p>{error.message}</p>
+      <button type="button" onClick={reset}>
+        もう一度試す
+      </button>
+    </div>
+  );
+};
+
+export default Error;

--- a/app/(feature)/form/hooks/usePostHelp/index.test.ts
+++ b/app/(feature)/form/hooks/usePostHelp/index.test.ts
@@ -58,12 +58,10 @@ describe('usePostHelp', () => {
 
     const { result } = renderHook(() => usePostHelp());
 
-    await expect(
-      result.current.postHelp(mockArgs, {
-        onSuccess: mockOnSuccess,
-        onError: mockOnError,
-      }),
-    ).rejects.toThrow(/Bad Request/);
+    await result.current.postHelp(mockArgs, {
+      onSuccess: mockOnSuccess,
+      onError: mockOnError,
+    });
 
     expect(triggerMock).toHaveBeenCalledWith(mockArgs);
     expect(mockOnError).toHaveBeenCalled();
@@ -79,15 +77,13 @@ describe('usePostHelp', () => {
 
     const { result } = renderHook(() => usePostHelp());
 
-    await expect(
-      result.current.postHelp(mockArgs, {
-        onSuccess: mockOnSuccess,
-        onError: mockOnError,
-      }),
-    ).rejects.toThrow('Network Error');
+    await result.current.postHelp(mockArgs, {
+      onSuccess: mockOnSuccess,
+      onError: mockOnError,
+    });
 
     expect(triggerMock).toHaveBeenCalledWith(mockArgs);
-    expect(mockOnError).toHaveBeenCalled();
+    expect(mockOnError).toHaveBeenCalledWith(expect.any(Error));
     expect(mockOnSuccess).not.toHaveBeenCalled();
   });
 });

--- a/app/(feature)/form/hooks/usePostHelp/index.ts
+++ b/app/(feature)/form/hooks/usePostHelp/index.ts
@@ -21,7 +21,7 @@ export const usePostHelp = () => {
 
   const postHelp = async (
     args: Props,
-    cb: { onSuccess: () => void; onError: (_error: any) => void },
+    cb: { onSuccess: () => void; onError: (_error: unknown) => void },
   ) => {
     try {
       const result = await trigger(args);
@@ -30,13 +30,11 @@ export const usePostHelp = () => {
         cb.onSuccess();
       } else {
         cb.onError(result);
-        throw new Error(result.statusText);
       }
 
       return { status: result.status, message: result.statusText };
     } catch (e) {
       cb.onError(e);
-      throw e;
     }
   };
   return {

--- a/app/(feature)/form/page.tsx
+++ b/app/(feature)/form/page.tsx
@@ -39,7 +39,7 @@ export default function Page() {
       },
       onError: (_error) => {
         // eslint-disable-next-line no-alert
-        alert(`エラーが発生しました: ${_error.message}`);
+        alert(`エラーが発生しました: ${_error instanceof Error ? _error.message : '不明なエラー'}`);
       },
     });
   };

--- a/app/libs/supabaseListener.ts
+++ b/app/libs/supabaseListener.ts
@@ -18,8 +18,8 @@ const SupabaseListener: React.FC<{ accessToken?: string }> = ({ accessToken }) =
           const auth = await fetchAuth({ email: data.session?.user.email || null });
           updateLoginUser({
             id: data.session?.user.id,
-            email: data.session?.user.email!,
-            auth: auth.result?.data?.[0]?.admin!,
+            email: data.session?.user.email ?? null,
+            auth: auth.result?.data?.[0]?.admin === true,
           });
         }
       } catch (error) {
@@ -39,15 +39,15 @@ const SupabaseListener: React.FC<{ accessToken?: string }> = ({ accessToken }) =
         const auth = await fetchAuth({ email: session.user.email || null });
         updateLoginUser({
           id: session.user.id,
-          email: session.user.email!,
-          auth: auth.result?.data?.[0]?.admin!,
+          email: session.user.email ?? null,
+          auth: auth.result?.data?.[0]?.admin === true,
         });
       } catch (error) {
         // fetchAuth失敗時でも基本情報は更新（authはundefinedのまま）
         console.warn('[SupabaseListener] admin判定に失敗:', error);
         updateLoginUser({
           id: session.user.id,
-          email: session.user.email!,
+          email: session.user.email ?? null,
           auth: undefined,
         });
       }


### PR DESCRIPTION
## 概要
supabaseListener・usePostHelp・dashboardの型安全性・エラーハンドリングを改善

## 変更内容
### 高優先度
- supabaseListener.ts: `email!` を `?? null` に、`admin!` を `=== true` に変更（3箇所の非nullアサーション削除）

### 中優先度
- usePostHelp: `onError` の型を `any` から `unknown` に変更
- usePostHelp: コールバック後の `throw` 削除でコールバック方式に統一
- usePostHelp: else→catchの二重 `onError` 呼び出しバグを修正
- form/page.tsx: `_error.message` に `instanceof Error` ガードを追加
- dashboard/error.tsx: Error Boundary を追加（form/loginと同パターン）
- usePostHelp テスト: `rejects.toThrow` からコールバック検証に変更

## テスト結果
- Jest: 3件パス
- Playwright E2E: 27件パス
