### PR TITLE
fix: afterAll を afterEach に変更してテスト間の状態漏れを防止

### DIFF
--- a/app/(feature)/dashboard/hooks/useFetchRawsData/helpers/getNowMonthFirstLast/index.test.ts
+++ b/app/(feature)/dashboard/hooks/useFetchRawsData/helpers/getNowMonthFirstLast/index.test.ts
@@ -5,7 +5,7 @@ describe('getNowMonthFirstLast', () => {
     jest.useFakeTimers();
   });
 
-  afterAll(() => {
+  afterEach(() => {
     jest.useRealTimers();
   });
 

--- a/app/(feature)/dashboard/index.test.tsx
+++ b/app/(feature)/dashboard/index.test.tsx
@@ -7,7 +7,7 @@ jest.mock('next/navigation', () => jest.requireActual('next-router-mock'));
 describe('Dashboard', () => {
   const user = userEvent.setup();
 
-  afterAll(() => {
+  afterEach(() => {
     jest.clearAllMocks();
   });
 

--- a/app/(feature)/form/index.test.tsx
+++ b/app/(feature)/form/index.test.tsx
@@ -12,11 +12,11 @@ const mockUseFetchPricesList = jest.mocked(useFetchPricesList);
 describe('Form', () => {
   const user = userEvent.setup();
 
-  beforeAll(() => {
+  beforeEach(() => {
     mockUseFetchPricesList.mockReturnValue(mockPricesListRaw);
   });
 
-  afterAll(() => {
+  afterEach(() => {
     jest.resetAllMocks();
   });
 


### PR DESCRIPTION
closes #380

## 変更内容

`afterAll` を `afterEach` に変更し、各テスト間でモックの状態が漏れないようにしました。

### 対象ファイル

- `app/(feature)/dashboard/index.test.tsx`: `afterAll` → `afterEach`
- `app/(feature)/form/index.test.tsx`: `beforeAll` → `beforeEach`, `afterAll` → `afterEach`
- `app/(feature)/dashboard/hooks/useFetchRawsData/helpers/getNowMonthFirstLast/index.test.ts`: `afterAll` → `afterEach`

### なぜ beforeAll も変更したか

`form/index.test.tsx` では `afterEach` で `resetAllMocks` を実行するため、各テスト前にモックを再セットアップする必要があり、`beforeAll` → `beforeEach` も合わせて変更しています。