### PR TITLE
fix: ランタイムクラッシュバグの修正

### DIFF
--- a/app/(feature)/form/components/PricesList/helpers/createPricesList/index.test.ts
+++ b/app/(feature)/form/components/PricesList/helpers/createPricesList/index.test.ts
@@ -3,6 +3,7 @@ import {
   mockPricesListErrorRaw,
   mockPricesListRaw,
 } from '@/mocks/pricesList';
+import { type PricesHelpsList } from '@/app/types';
 import { createPricesList } from '.';
 
 describe('createPricesList', () => {
@@ -14,5 +15,25 @@ describe('createPricesList', () => {
   test('rawデータにエラーがある場合はnullになる', () => {
     const pricesList = createPricesList(mockPricesListErrorRaw);
     expect(pricesList).toBeNull();
+  });
+
+  test('prices_listが空配列の場合はvalueが0になる', () => {
+    const rawWithEmptyPrices: PricesHelpsList = {
+      data: [
+        {
+          created_at: '2021-10-01T00:00:00.000000Z',
+          help: 'dish',
+          id: 'dish',
+          label: '皿洗い',
+          update_at: null,
+          prices_list: [],
+        },
+      ],
+      error: null,
+    };
+    const pricesList = createPricesList(rawWithEmptyPrices);
+    expect(pricesList).toStrictEqual([
+      { id: 'dish', label: '皿洗い', column: 'dish', value: 0 },
+    ]);
   });
 });

--- a/app/(feature)/form/components/PricesList/helpers/createPricesList/index.ts
+++ b/app/(feature)/form/components/PricesList/helpers/createPricesList/index.ts
@@ -7,7 +7,7 @@ export const createPricesList = (pricesListRaw: PricesHelpsList | undefined) => 
     id: item.id,
     label: item.label,
     column: item.help,
-    value: item.prices_list[0].price,
+    value: item.prices_list[0]?.price ?? 0,
   }));
 
   return pricesList;

--- a/app/(feature)/form/helpers/convertHelps/index.test.ts
+++ b/app/(feature)/form/helpers/convertHelps/index.test.ts
@@ -26,4 +26,54 @@ describe('convertHelps', () => {
       special: 50,
     });
   });
+
+  test('空配列の場合はデフォルト値が返る', () => {
+    const result = convertHelps([]);
+    expect(result).toStrictEqual({
+      dish: 0,
+      curtain: 0,
+      prepareEat: 0,
+      landry: 0,
+      special: 0,
+    });
+  });
+
+  test('空文字列が含まれる場合はスキップされる', () => {
+    const data = ['dish,30', '', 'special,50'];
+
+    const result = convertHelps(data);
+    expect(result).toStrictEqual({
+      dish: 30,
+      curtain: 0,
+      prepareEat: 0,
+      landry: 0,
+      special: 50,
+    });
+  });
+
+  test('カンマなし文字列はスキップされる', () => {
+    const data = ['dish,30', 'invalidEntry', 'special,50'];
+
+    const result = convertHelps(data);
+    expect(result).toStrictEqual({
+      dish: 30,
+      curtain: 0,
+      prepareEat: 0,
+      landry: 0,
+      special: 50,
+    });
+  });
+
+  test('価格が数値でない場合はスキップされる', () => {
+    const data = ['dish,abc', 'special,50'];
+
+    const result = convertHelps(data);
+    expect(result).toStrictEqual({
+      dish: 0,
+      curtain: 0,
+      prepareEat: 0,
+      landry: 0,
+      special: 50,
+    });
+  });
 });

--- a/app/(feature)/form/helpers/convertHelps/index.ts
+++ b/app/(feature)/form/helpers/convertHelps/index.ts
@@ -8,7 +8,10 @@ export const convertHelps = (data: string[]) => {
   };
   return data.reduce((acc, help) => {
     const [key, priceStr] = help.split(',');
-    const helpEntry = { [key]: Number(priceStr) };
+    if (!key || priceStr === undefined) return acc;
+    const price = Number(priceStr);
+    if (Number.isNaN(price)) return acc;
+    const helpEntry = { [key]: price };
 
     return { ...acc, ...helpEntry };
   }, defaultHelps);

--- a/app/(feature)/navHeader/index.tsx
+++ b/app/(feature)/navHeader/index.tsx
@@ -4,12 +4,12 @@ import { useStore } from '@/app/store';
 import { useSignOut } from './hooks';
 
 const navItemsWithAdmin = {
-  Form: './form',
-  Dashboard: './dashboard',
+  Form: '/form',
+  Dashboard: '/dashboard',
 };
 
 const navItemsWithMember = {
-  Dashboard: './dashboard',
+  Dashboard: '/dashboard',
 };
 
 export const NavHeader = () => {


### PR DESCRIPTION
## 概要
ランタイムで発生しうるクラッシュバグ3件を修正し、対応するテストを追加しました。

## 変更内容

### 1. createPricesList: 空の prices_list でクラッシュする問題を修正
- `item.prices_list[0].price` → `item.prices_list[0]?.price ?? 0`
- prices_list が空配列の場合に Cannot read properties of undefined が発生していた

### 2. convertHelps: 不正な入力文字列でクラッシュする問題を修正
- 空文字列、カンマなし文字列、非数値の価格に対するガード処理を追加
- key が空または priceStr が undefined の場合に早期リターン
- Number.isNaN(price) で数値バリデーション

### 3. navHeader: 相対パスを絶対パスに修正
- './form' → '/form', './dashboard' → '/dashboard'
- 相対パスだと現在のURLに依存してナビゲーションが壊れる可能性があった

## テスト
- createPricesList: 空配列ケースのテスト追加（1件）
- convertHelps: エッジケーステスト追加（4件）
- 全テスト通過: 31 suites / 132 tests passed
