### PR TITLE
refactor: ログイン・フォームページの冗長コード削除

### DIFF
--- a/app/(feature)/form/page.tsx
+++ b/app/(feature)/form/page.tsx
@@ -7,19 +7,13 @@ import { Section } from '@/app/components/Section';
 import { Textarea } from '@/app/components/Textarea';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { PricesList } from './components/PricesList';
 import { convertHelps, validationSchema, type FormProps } from './helpers';
 
 export default function Page() {
-  const [isClient, setIsClient] = useState(false);
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
-
   const { postHelp, isMutating } = usePostHelp();
 
   const router = useRouter();
@@ -57,67 +51,65 @@ export default function Page() {
   useLeavingModal(isDirty);
 
   return (
-    isClient && (
-      <div className="w-100  h-200 m-10 text-center">
-        <form onSubmit={handleSubmit(onSubmit)}>
+    <div className="w-100  h-200 m-10 text-center">
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Controller
+          name="person"
+          control={control}
+          defaultValue=""
+          rules={{
+            required: true,
+          }}
+          render={({ field }) => (
+            <Section>
+              <Radio id="eito" label="eito" {...field} value="eito" />
+              <Radio id="mei" label="mei" {...field} value="mei" />
+              <Radio id="tohhiro" label="tohhiro" {...field} value="tohhiro" />
+            </Section>
+          )}
+        />
+        <div className="my-2 m-auto">
+          <ErrorContainer>{errors.person && errors.person.message}</ErrorContainer>
+        </div>
+        <Section>
           <Controller
-            name="person"
+            name="items.helps"
             control={control}
-            defaultValue=""
-            rules={{
-              required: true,
-            }}
-            render={({ field }) => (
-              <Section>
-                <Radio id="eito" label="eito" {...field} value="eito" />
-                <Radio id="mei" label="mei" {...field} value="mei" />
-                <Radio id="tohhiro" label="tohhiro" {...field} value="tohhiro" />
-              </Section>
+            defaultValue={[]}
+            rules={{ required: true }}
+            render={() => (
+              <>
+                <ErrorBoundary fallback={<p>エラーが発生しました</p>}>
+                  <Suspense fallback={<p>...Loading</p>}>
+                    <PricesList register={{ ...register('items.helps') }} />
+                  </Suspense>
+                </ErrorBoundary>
+              </>
             )}
           />
-          <div className="my-2 m-auto">
-            <ErrorContainer>{errors.person && errors.person.message}</ErrorContainer>
-          </div>
-          <Section>
-            <Controller
-              name="items.helps"
-              control={control}
-              defaultValue={[]}
-              rules={{ required: true }}
-              render={() => (
-                <>
-                  <ErrorBoundary fallback={<p>エラーが発生しました</p>}>
-                    <Suspense fallback={<p>...Loading</p>}>
-                      <PricesList register={{ ...register('items.helps') }} />
-                    </Suspense>
-                  </ErrorBoundary>
-                </>
-              )}
-            />
 
-            <ErrorContainer>{errors.items?.helps && errors.items.helps.message}</ErrorContainer>
-          </Section>
+          <ErrorContainer>{errors.items?.helps && errors.items.helps.message}</ErrorContainer>
+        </Section>
 
-          <Controller
-            name="items.comments"
-            control={control}
-            defaultValue=""
-            rules={{
-              required: true,
-            }}
-            render={({ field }) => (
-              <Section>
-                <Textarea id="textarea" label="備考" placeholder="備考があれば入力" {...field} />
-              </Section>
-            )}
-          />
-          <ErrorContainer>{errors.items?.comments && errors.items.comments.message}</ErrorContainer>
+        <Controller
+          name="items.comments"
+          control={control}
+          defaultValue=""
+          rules={{
+            required: true,
+          }}
+          render={({ field }) => (
+            <Section>
+              <Textarea id="textarea" label="備考" placeholder="備考があれば入力" {...field} />
+            </Section>
+          )}
+        />
+        <ErrorContainer>{errors.items?.comments && errors.items.comments.message}</ErrorContainer>
 
-          <Section>
-            <Button label="Submit" type="submit" intent={isMutating ? 'disabled' : 'primary'} />
-          </Section>
-        </form>
-      </div>
-    )
+        <Section>
+          <Button label="Submit" type="submit" intent={isMutating ? 'disabled' : 'primary'} />
+        </Section>
+      </form>
+    </div>
   );
 }

--- a/app/(feature)/login/page.tsx
+++ b/app/(feature)/login/page.tsx
@@ -16,8 +16,7 @@ export default function Page() {
   const {
     formState: { errors },
     control,
-    getValues,
-    trigger,
+    handleSubmit,
   } = useForm<LoginProps>({
     mode: 'onChange',
     resolver: zodResolver(validationSchema),
@@ -40,20 +39,9 @@ export default function Page() {
     });
   };
 
-  const handleFormSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    const isValid = await trigger();
-    if (!isValid) return;
-    const values = getValues();
-    await onSubmit(values);
-  };
-
   return (
     <div className={'w-100  h-200 m-10 text-center'}>
-      <form
-        onSubmit={handleFormSubmit}
-      >
+      <form onSubmit={handleSubmit(onSubmit)}>
         <Section>
           <Controller
             name="email"

--- a/app/components/Button/index.tsx
+++ b/app/components/Button/index.tsx
@@ -14,7 +14,7 @@ export const Button = ({ label, type, intent, onClick }: Props) => {
       <button
         className={buttonStyles({ intent })}
         type={type}
-        disabled={intent === 'disabled' || false}
+        disabled={intent === 'disabled'}
         onClick={onClick}
       >
         {label}


### PR DESCRIPTION
## 概要

#402 に対応。ログイン・フォームページ・Buttonコンポーネントの冗長コードを削除。

## 変更内容

### C-3: login/page.tsx — handleSubmit統一
- `trigger()` + `getValues()` の手動バリデーション・取得パターンを削除
- react-hook-form 標準の `handleSubmit(onSubmit)` に統一

### C-4: form/page.tsx — isClient削除
- `'use client'` ディレクティブがあるため不要な `isClient` + `useState` + `useEffect` を削除
- `isClient && (...)` のラップを外し、常にレンダーされる形に変更

### C-5: Button/index.tsx — || false 削除
- `disabled={intent === 'disabled' || false}` → `disabled={intent === 'disabled'}`
- `=== 'disabled'` が既に boolean を返すため `|| false` は無意味

## 品質チェック

- [x] typecheck
- [x] lint
- [x] test:unit (148テスト全パス)
- [x] build

Closes #402
