### PR TITLE
fix: E2E テストで logout・Dashboard 遷移が失敗する問題を修正

### DIFF
--- a/app/(feature)/form/page.tsx
+++ b/app/(feature)/form/page.tsx
@@ -45,6 +45,7 @@ export default function Page() {
     control,
   } = useForm<FormProps>({
     mode: 'onChange',
+    defaultValues: { person: '', items: { helps: [], comments: '' } },
     resolver: zodResolver(validationSchema),
   });
 
@@ -56,7 +57,6 @@ export default function Page() {
         <Controller
           name="person"
           control={control}
-          defaultValue=""
           rules={{
             required: true,
           }}
@@ -72,21 +72,11 @@ export default function Page() {
           <ErrorContainer>{errors.person && errors.person.message}</ErrorContainer>
         </div>
         <Section>
-          <Controller
-            name="items.helps"
-            control={control}
-            defaultValue={[]}
-            rules={{ required: true }}
-            render={() => (
-              <>
-                <ErrorBoundary fallback={<p>エラーが発生しました</p>}>
-                  <Suspense fallback={<p>...Loading</p>}>
-                    <PricesList register={{ ...register('items.helps') }} />
-                  </Suspense>
-                </ErrorBoundary>
-              </>
-            )}
-          />
+          <ErrorBoundary fallback={<p>エラーが発生しました</p>}>
+            <Suspense fallback={<p>...Loading</p>}>
+              <PricesList register={{ ...register('items.helps') }} />
+            </Suspense>
+          </ErrorBoundary>
 
           <ErrorContainer>{errors.items?.helps && errors.items.helps.message}</ErrorContainer>
         </Section>
@@ -94,7 +84,6 @@ export default function Page() {
         <Controller
           name="items.comments"
           control={control}
-          defaultValue=""
           rules={{
             required: true,
           }}


### PR DESCRIPTION
## 概要

admin ユーザーでログインした場合、E2E テストの logout・Dashboard 遷移テストが全ブラウザで一貫して失敗していた問題を修正。

## 原因

`app/(feature)/form/page.tsx` で `items.helps` フィールドに `Controller` と `register` が同時に使用されていた。

```tsx
// 修正前: Controller の render 内で field を使わず register を渡していた
<Controller
  name="items.helps"
  control={control}
  defaultValue={[]}
  render={() => (
    <PricesList register={{ ...register("items.helps") }} />
  )}
/>
```

- Controller が `defaultValue={[]}` でフィールドを内部登録
- register が同一フィールド名で別途登録し上書き
- 内部の defaultValue 参照がずれて `isDirty = true` に
- `useLeavingModal` の `confirm()` ダイアログが未入力時にも発火
- Playwright はダイアログをデフォルトで dismiss するため全ナビゲーションがブロック

## 修正内容

- `items.helps` の `Controller` を除去し `register` のみに統一
- `defaultValues` を `useForm` に集約
- 各 Controller の個別 `defaultValue` を除去

## テスト結果

| チェック | 結果 |
|---|---|
| `npm run typecheck` | 通過 |
| `npm run lint` | 通過 |
| `npm run test:unit` | 148/148 通過 |
| `npm run test:e2e` | 27/27 通過（修正前: 21 passed / 6 failed） |
| `npm run build` | 成功 |

Closes #427