### PR TITLE
chore: VS Code 設定でビルド成果物フォルダを除外

### DIFF
--- a/.vscode/setting.json
+++ b/.vscode/setting.json
@@ -1,8 +1,0 @@
-{
-  "editor.defaultFormatter": null,
-  "editor.formatOnSave": true,
-  "jest.autoRun": "off",
-  "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,23 @@
 {
+  "editor.defaultFormatter": null,
+  "editor.formatOnSave": true,
+  "jest.autoRun": "off",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "files.exclude": {
     "playwright-report": true,
     "test-results": true,
     "storybook-static": true
+  },
+  "search.exclude": {
+    "playwright-report": true,
+    "test-results": true,
+    "storybook-static": true
+  },
+  "files.watcherExclude": {
+    "playwright-report/**": true,
+    "test-results/**": true,
+    "storybook-static/**": true
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "files.exclude": {
+    "playwright-report": true,
+    "test-results": true,
+    "storybook-static": true
+  }
+}


### PR DESCRIPTION
## 概要

`.vscode/settings.json` を追加し、ビルド成果物フォルダを VS Code のエクスプローラーとエラー検出から除外。

## 除外対象

- `playwright-report/` — Playwright テストレポート
- `test-results/` — Playwright テスト結果
- `storybook-static/` — Storybook ビルド出力

いずれも自動生成されるファイルで、エディタ上の不要なエラー表示（HTML の lang 属性欠如等）を防止する。