### PR TITLE
chore: CSS インポートの型宣言ファイルを追加

### DIFF
--- a/css.d.ts
+++ b/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';


### PR DESCRIPTION
## 概要

`globals.css` の副作用インポートで TypeScript の型エラーが発生していたため、`css.d.ts` を追加して解消。

## 原因

TypeScript に `.css` ファイルのモジュール型宣言がなく、10箇所の `import "*.css"` でエラーが発生していた。

## 修正内容

ルートに `css.d.ts` を追加:

```typescript
declare module "*.css";
```

## 品質チェック

| チェック | 結果 |
|---|---|
| `npm run typecheck` | 通過 |
| `npm run lint` | 通過 |
| `npm run test:unit` | 148/148 通過 |
| `npm run build` | 成功 |

Closes #430