### PR TITLE
chore: tsconfig.json の非推奨オプションを更新

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
## 概要

TypeScript 5.9.3 で非推奨警告が出ていた `tsconfig.json` のオプションを Next.js 14 推奨設定に更新。

## 変更内容

| オプション | 変更前 | 変更後 |
|---|---|---|
| `target` | `es5` | `es2017` |
| `moduleResolution` | `node` | `bundler` |

### 理由
- `target: "es2017"` — Next.js は SWC でトランスパイルするため TypeScript 側で ES5 まで落とす必要がない
- `moduleResolution: "bundler"` — webpack/turbopack のモジュール解決に適合。`node` は CommonJS 向けで ESM + バンドラー環境には不適



## 品質チェック

| チェック | 結果 |
|---|---|
| `npm run typecheck` | 通過 |
| `npm run lint` | 通過 |
| `npm run test:unit` | 148/148 通過 |
| `npm run build` | 成功 |

Closes #429