### PR TITLE
refactor: forwardRef の ref 転送・型安全性・displayName 改善

### DIFF
--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import '@/app/styles/globals.css';
 import Link from 'next/link';
 import { useState } from 'react';

--- a/app/components/Input/index.tsx
+++ b/app/components/Input/index.tsx
@@ -22,8 +22,8 @@ type HiddenProps = {
 
 export type Props = DefaultProps | HiddenProps;
 
-export const Input = forwardRef(
-  ({ id, label, type, onClick, placeholder, disabled, ...field }: Props, _ref) => {
+export const Input = forwardRef<HTMLInputElement, Props>(
+  ({ id, label, type, onClick, placeholder, disabled, ...field }: Props, ref) => {
     return (
       <div>
         <label htmlFor={id} className={labelStyles.label}>
@@ -31,6 +31,7 @@ export const Input = forwardRef(
         </label>
         <input
           {...field}
+          ref={ref}
           id={id}
           placeholder={placeholder}
           onClick={onClick}
@@ -42,3 +43,5 @@ export const Input = forwardRef(
     );
   },
 );
+
+Input.displayName = 'Input';

--- a/app/components/Radio/index.tsx
+++ b/app/components/Radio/index.tsx
@@ -9,13 +9,24 @@ export type Props = {
   name?: string;
 };
 
-export const Radio = forwardRef(({ id, label, value, ...field }: Props, _ref) => {
-  return (
-    <div className={radioStyles.container}>
-      <input {...field} type="radio" id={id} className={radioStyles.radio} value={value} />
-      <label htmlFor={id} className={radioStyles.label}>
-        {label}
-      </label>
-    </div>
-  );
-});
+export const Radio = forwardRef<HTMLInputElement, Props>(
+  ({ id, label, value, ...field }: Props, ref) => {
+    return (
+      <div className={radioStyles.container}>
+        <input
+          {...field}
+          ref={ref}
+          type="radio"
+          id={id}
+          className={radioStyles.radio}
+          value={value}
+        />
+        <label htmlFor={id} className={radioStyles.label}>
+          {label}
+        </label>
+      </div>
+    );
+  },
+);
+
+Radio.displayName = 'Radio';

--- a/app/components/SelectBox/index.tsx
+++ b/app/components/SelectBox/index.tsx
@@ -1,5 +1,5 @@
 import '@/app/styles/globals.css';
-import { forwardRef } from 'react';
+import { type ComponentRef, forwardRef } from 'react';
 import Select from 'react-select';
 import { SelectBoxStyles } from './index.styles';
 
@@ -8,7 +8,10 @@ export type Props = {
   label: string;
 };
 
-export const SelectBox = forwardRef(
+export const SelectBox = forwardRef<
+  ComponentRef<typeof Select>,
+  { options: Props[]; label: string; id: string; isDisabled?: boolean }
+>(
   (
     {
       options,
@@ -17,7 +20,7 @@ export const SelectBox = forwardRef(
       isDisabled,
       ...field
     }: { options: Props[]; label: string; id: string; isDisabled?: boolean },
-    _ref,
+    ref,
   ) => {
     return (
       <div>
@@ -26,6 +29,7 @@ export const SelectBox = forwardRef(
         </label>
         <Select
           {...field}
+          ref={ref}
           id={id}
           name="selects"
           inputId="selects"
@@ -39,3 +43,5 @@ export const SelectBox = forwardRef(
     );
   },
 );
+
+SelectBox.displayName = 'SelectBox';

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -1,40 +1,43 @@
-import { forwardRef } from 'react';
 import '../../styles/globals.css';
 import { tableStyles } from './index.styles';
 
 export type Props = Record<string, string | number | null | React.ReactNode>[];
 
-export const Table = forwardRef(
-  ({ thData, tdData }: { thData: Record<string, string>; tdData: Props | null }, _ref) => {
-    if (!tdData || !tdData[0]) {
-      return <div>データがありません</div>;
-    }
-    if (Object.keys(thData).length !== Object.keys(tdData[0]).length) {
-      return <div>要素の数が異なるため表示できません</div>;
-    }
-    return (
-      <table className={tableStyles.table}>
-        <thead className={tableStyles.thead}>
-          <tr>
-            {Object.keys(thData).map((key: string, idx) => (
-              <th key={`${idx}${key}`} className={tableStyles.th}>
-                {thData[key]}
-              </th>
+export const Table = ({
+  thData,
+  tdData,
+}: {
+  thData: Record<string, string>;
+  tdData: Props | null;
+}) => {
+  if (!tdData || !tdData[0]) {
+    return <div>データがありません</div>;
+  }
+  if (Object.keys(thData).length !== Object.keys(tdData[0]).length) {
+    return <div>要素の数が異なるため表示できません</div>;
+  }
+  return (
+    <table className={tableStyles.table}>
+      <thead className={tableStyles.thead}>
+        <tr>
+          {Object.keys(thData).map((key: string, idx) => (
+            <th key={`${idx}${key}`} className={tableStyles.th}>
+              {thData[key]}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {tdData.map((item, idxA) => (
+          <tr key={idxA} className={tableStyles.tr}>
+            {Object.keys(item).map((key, idxB) => (
+              <td key={`${idxB}${key}`} className={tableStyles.td}>
+                {item[key]}
+              </td>
             ))}
           </tr>
-        </thead>
-        <tbody>
-          {tdData.map((item, idxA) => (
-            <tr key={idxA} className={tableStyles.tr}>
-              {Object.keys(item).map((key, idxB) => (
-                <td key={`${idxB}${key}`} className={tableStyles.td}>
-                  {item[key]}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    );
-  },
-);
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/app/components/Textarea/index.tsx
+++ b/app/components/Textarea/index.tsx
@@ -8,13 +8,23 @@ export type Props = {
   placeholder?: string;
 };
 
-export const Textarea = forwardRef(({ label, id, placeholder, ...field }: Props, _ref) => {
-  return (
-    <div>
-      <label htmlFor={id} className={textareaStyles.label}>
-        {label}
-      </label>
-      <textarea {...field} id={id} className={textareaStyles.textarea} placeholder={placeholder} />
-    </div>
-  );
-});
+export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
+  ({ label, id, placeholder, ...field }: Props, ref) => {
+    return (
+      <div>
+        <label htmlFor={id} className={textareaStyles.label}>
+          {label}
+        </label>
+        <textarea
+          {...field}
+          ref={ref}
+          id={id}
+          className={textareaStyles.textarea}
+          placeholder={placeholder}
+        />
+      </div>
+    );
+  },
+);
+
+Textarea.displayName = 'Textarea';


### PR DESCRIPTION
## 概要

共通 UI コンポーネントの `forwardRef` 実装を改善し、ref の DOM 転送、型安全性、displayName を修正します。

関連 issue: #401

## 変更内容

### D-2: ref の DOM 転送
- **Input**: ref を input 要素に転送
- **Radio**: ref を input 要素に転送
- **Textarea**: ref を textarea 要素に転送
- **SelectBox**: ref を Select に転送

### D-3: `forwardRef` 型パラメータ追加
- Input: `forwardRef<HTMLInputElement, Props>`
- Radio: `forwardRef<HTMLInputElement, Props>`
- Textarea: `forwardRef<HTMLTextAreaElement, Props>`
- SelectBox: `forwardRef<ComponentRef<typeof Select>, ...>`

### D-4: `displayName` 設定
- 全 `forwardRef` コンポーネントに `Component.displayName = 'ComponentName'` を追加
- React DevTools でのデバッグが容易になります

### D-5: Table コンポーネントの改善
- 不要な `forwardRef` を除去（ref が使用されないため）

### E-4: Header コンポーネント
- `useState` を使用しているため `'use client'` ディレクティブを追加

## テスト結果

✅ npm run typecheck - エラーなし
✅ npm run lint - エラーなし
✅ npm run test:unit - 153 テスト全てパス
✅ npm run build - ビルド成功

## メリット

- 全コンポーネントで ref が実際の DOM 要素に転送される
- 型安全性が向上（as any の使用がない）
- React DevTools でコンポーネント名が正しく表示される
- 外部からの ref アクセスが正常に機能する