### PR TITLE
refact: HeaderコンポーネントのUTをsetup関数を使ってrender、userEventを返すように改修

### DIFF
--- a/app/components/Header/index.test.tsx
+++ b/app/components/Header/index.test.tsx
@@ -18,6 +18,13 @@ jest.mock('next/link', () => {
   );
 });
 
+const setup = (jsx: JSX.Element) => {
+  return {
+    user: userEvent.setup(),
+    ...render(jsx),
+  };
+};
+
 const mockNavItems = { Form: './form', Dashboard: './dashboard' };
 
 const mockLoginUser = 'test@test.com';
@@ -34,7 +41,7 @@ describe('Header', () => {
   });
 
   test('Headerのタイトルがレンダーされる', () => {
-    render(<Header {...mockData} />);
+    setup(<Header {...mockData} />);
     const headerComponent = screen.getByText(headerText);
     expect(headerComponent).toBeInTheDocument();
   });
@@ -44,17 +51,16 @@ describe('Header', () => {
     ${'Form'}      | ${'./form'}      | ${(<a href="./form">Form</a>)}
     ${'Dashboard'} | ${'./dashboard'} | ${(<a href="./dashboard">Dashboard</a>)}
   `('HeaderのnavとなるLinkがそれぞれ対応するhref属性をもつ', ({ linkName, href }) => {
-    render(<Header {...mockData} />);
+    setup(<Header {...mockData} />);
 
     const link = screen.getByRole('link', { name: linkName });
     expect(link).toHaveAttribute('href', href);
   });
 
   test('Logoutをクリックすると、propsで渡したonClick関数が1回実行される', async () => {
-    render(<Header {...mockData} />);
+    const { user } = setup(<Header {...mockData} />);
 
     const logout = screen.getByText(mockLoginUser);
-    const user = userEvent.setup();
     await user.click(logout);
     expect(mockData.onClick).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
- setup関数でHeaderコンポーネントをrender
- 上記に加え、userEventをsetup関数で返す